### PR TITLE
Modify script to work for buddy pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This repo contains various scripts to automatically reserve ski days for epic pa
   - This script uses a configurable delay between actions. The purpose of this delay is to wait for api calls and loading times. ***Warning: this has not been updated with feature improvements only use this if the async script fails for some reason*** 
 - [Async Function Based Reservation Script](https://github.com/dangothemango/epic-reservations/blob/main/scripts/asyncReservationMaker.js)
   - This script is based on async function calls and can detect when the epic pass reservation page is loading. This checks availablility at a theoretically optimal rate.
+- [Async Reservation Script for Buddy Passes](https://github.com/dangothemango/epic-reservations/blob/main/scripts/asyncReservationMaker_buddy.js)
+  - This script is the same as the async script above, but for reserving buddy passes. Because this option requires payment, you would still have to check out manually (do so quickly before someone else snags the spot). You only need to use this script if the desired day is already booked. I've had a 100% success rate with finding a spot even if it's booked. See usage instructions [below](#usage-instructions-buddy-pass).
 
 ## Usage Instructions
 
@@ -26,6 +28,17 @@ This repo contains various scripts to automatically reserve ski days for epic pa
 5. Copy and paste the script with your set variables into the web console. make sure to get the whole thing (cmd+a). (when its pasted make sure to hit enter)
 6. type `start()` into the console and hit enter.
 7. Profit
+
+## Usage Instructions: Buddy Pass
+
+1. Follow steps 1 and 2 from above.
+2. Navigate to the [Season Passes](https://www.epicpass.com/account/my-account.aspx?ma_1=4) tab of the My Account page.
+3. Click on "Benefit Tickets", then "Buy for a Buddy", then "Get Started".
+4. Open up the JavaScript Web console. On Chrome for the Mac, it's Option+Command+J. You can also do this by right clicking, selecting inspect element, and then clicking "Console", but its different by browser. If you're confused, Google it.
+5. Copy and paste the script with your set variables into the web console. make sure to get the whole thing (cmd+a). (when its pasted make sure to hit enter)
+6. Type `start()` into the console and hit enter.
+7. It will run until it finds an open spot. It will then open a new tab so that you can continue the checkout process. Do so quickly so you don't lose the spot.
+8. Profit
 
 ## Current Limitations
 - Assumes that the passholders in question do not something preventing them from reserving on that day

--- a/scripts/asyncReservationMaker_buddy.js
+++ b/scripts/asyncReservationMaker_buddy.js
@@ -1,0 +1,240 @@
+desiredDays = ['3/13']
+mountains = ['Kirkwood'] // use the name
+
+// Afton Alps               =   "11"
+// Alpine Valley            =   "232"
+// Attitash Mountain        =   "203"
+// Beaver Creek             =   "2"
+// Boston Mills Brandywine  =   "212"
+// Breckenridge             =   "3"
+// Crested Butte            =   "15"
+// Crotched Mountain        =   "205"
+// Heavenly                 =   "6"
+// Hidden Valley            =   "1218"
+// Hunter                   =   "73"
+// Keystone                 =   "4"
+// Kirkwood                 =   "9"
+// Liberty Mountain         =   "206"
+// Mad River Mountain       =   "201"
+// Mount Sunapee            =   "87"
+// Mt Brighton              =   "12"
+// Mt Snow                  =   "74"
+// Northstar                =   "8"
+// Okemo                    =   "86"
+// Paoli Peaks              =   "1219"
+// Park City                =   "14"
+// Roundtop Mountain        =   "207"
+// Snow Creek               =   "202"
+// Stevens Pass             =   "44"
+// Stowe                    =   "85"
+// Vail                     =   "1"
+// Whistler Blackcomb       =   "80"
+// Whitetail                =   "208"
+// Wildcat Mountain         =   "204"
+// Wilmot Mountain          =   "43"
+
+monthOrder = []
+activeMonth = new Date().getMonth()+1
+
+mountainSelect = document.getElementById('benefit_ticket_modal__content__resort_input')
+
+nativeSelectValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLSelectElement.prototype,
+      "value"
+    ).set;
+
+changeEvent = new Event('change', { bubbles: true});
+
+async function prepareMonthOrder() {
+    currentMonth = new Date().getMonth()+1
+    for (let i = currentMonth; i < currentMonth+12; i++) {
+        monthOrder.push(i%12)
+    }
+    var index = monthOrder.indexOf(0);
+    if (index !== -1) {
+        monthOrder[index] = 12;
+    }
+    //console.log(monthOrder)
+}
+
+async function resetActiveMonth() {
+    activeMonth = new Date().getMonth()+1
+}
+
+async function timeout(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForLoad() {
+    await timeout(100)
+    if ($("[class*=loading_spinner").length !== 0) {
+        //console.log('loading')
+        await waitForLoad()
+    } else {
+        //console.log('loaded')
+    }
+}
+
+async function changeMountain(val) {
+    console.log("changing mountain to " + val)
+    //mountainSelect.selectedIndex=14
+    nativeSelectValueSetter.call(mountainSelect, val)
+    mountainSelect.dispatchEvent(changeEvent)
+    $(".input-group-addon").click()
+    console.log('waiting for mountain to change')
+    resetActiveMonth()
+    await waitForLoad()
+    console.log('changedMountain')
+}
+
+async function increaseMonth() {
+    $("button[title='Next Month']").click()
+    activeMonth = (activeMonth + 1)%12
+    if (activeMonth === 0) {
+        activeMonth = 12
+    }
+    await waitForLoad()
+}
+
+async function decreaseMonth() {
+    $("button[title='Previous Month']").click()
+    activeMonth = (activeMonth - 1)%12
+    if (activeMonth === 0) {
+        activeMonth = 12
+    }
+    await waitForLoad()
+}
+
+async function setMonth(month) {
+    //console.log('setting month')
+    if (month === activeMonth.toString()) {
+        return
+    }
+    let activeIndex = monthOrder.indexOf(activeMonth)
+    let desiredIndex = monthOrder.indexOf(parseInt(month))
+    if (activeIndex > desiredIndex) {
+        await decreaseMonth()
+    } else {
+        await increaseMonth()
+    }
+    await setMonth(month)
+}
+
+async function getElementForDay(date) {
+    console.log('getting day ' + date)
+    let month, day
+    if (date.includes('/')) {
+        month = date.split('/')[0]
+        day = date.split('/')[1]
+    } else {
+        month = activeMonth
+        day = date
+    }
+    console.log(month + '/' + day)
+    await setMonth(month)
+    console.log('Table: ' + $(".table-condensed td").length)
+    for (element of $(".table-condensed td")) {
+        console.log('Day: ' + day)
+        if (element.innerHTML === day) {
+            return element
+        }
+    }
+}
+
+async function reserveDay(dayElement) {
+    dayElement.click();
+    console.log('loading checkboxes')
+    await waitForLoad()
+    console.log('checkboxes loaded')
+    return true
+}
+
+async function nextMountain(index) {
+    if (mountains.length === 1) {
+        await changeMountain("Jack Frost Big Boulder")
+        doTheWork(0)
+    } else {
+        doTheWork((index+1)%mountains.length)
+    }
+}
+
+async function tryReserveDay(day) {
+    console.log('trying to reserve ' + day)
+    dayElement = await getElementForDay(day)
+    return !dayElement.classList.contains('disabled') && (await reserveDay(dayElement));
+}
+
+async function finalizeReservations() {
+    await waitForLoad()
+    $("#benefit_ticket_modal__content__attestment_input")[0].checked = true
+    //$("#benefit_ticket_modal__content__attestment_input")[0].click()
+    document.getElementsByClassName('benefit_ticket_modal__option_submit primaryCTA')[0].click()
+}
+
+async function extendSession() {
+    // Extend our session and clear the dialog if it's up.
+    await requirejs(['FR', 'jquery', 'underscore', 'moment', 'services/freerideRestApi'], function(FR, $, _, moment, restApi) {
+
+        var _helper = {
+            closeModal: function closeModal() {
+            FR.$el.window.trigger('global-modal-close');
+            },
+            openModal: function openModal() {
+            var template = _helper.getTemplate();
+    
+            setTimeout(function() {
+                FR.$el.window.trigger('global-modal-open', [template]);
+            }, 1000);
+            },
+            getTemplate: function getTemplate() {
+            var template = _.template(_$el.template.html());
+    
+            return template({});
+            },
+            startSessionWarning: function startSessionWarning() {
+            if (FR.$el.body.attr('data-session-active') === 'true' && FR.$el.body.attr('data-user-authentication-status') === 'logged in') {
+                _showModalTime = moment().add(parseInt(FR.$el.body.attr('data-session-time'), 10) - 2, 'm');
+    
+                //_helper.checkForSessionWarning();
+            }
+            }
+        }
+        //console.log("extending session");
+        restApi.extendSession({}, function(response) {
+            _helper.closeModal();
+    
+            if (response.success === true) {
+            //console.log("successful extend");
+            FR.$el.body.attr('data-session-time', response.data);
+    
+            _helper.startSessionWarning();
+    
+            FR.$el.window.trigger('session-extended');
+            } else {
+            //console.log("unsuccessful extend");
+    
+            }
+        });
+    });
+}
+
+async function doTheWork(index) {
+    await extendSession();
+
+    await changeMountain(mountains[index]);
+    let foundDay = false
+    for (day of desiredDays) {
+        console.log("loop processing day " + day)
+        foundDay = (await tryReserveDay(day)) || foundDay
+    }
+    if (!foundDay) {
+        nextMountain(index)
+    } else {
+        finalizeReservations()
+    }
+}
+
+function start() {
+    prepareMonthOrder()
+    doTheWork(0)
+}


### PR DESCRIPTION
I modified the script so that it works for purchasing buddy/SWAF pass as well. It does the search after you first go to the buddy page popup. It merely finds the reservation - it does not complete the purchase since you have to enter your CC info. If a mountain is full, it may take a few minutes to find an opening (make sure to complete the purchase quickly to lock down the spot).

Just thought it'd be helpful for anyone who wants to have a script for buddy passes as well.